### PR TITLE
Add new line to IPv4 file

### DIFF
--- a/cloudflare-sync-ips.sh
+++ b/cloudflare-sync-ips.sh
@@ -49,6 +49,7 @@ if [ "$responseipv4" == "200" ] && [ "$responseipv6" == "200" ]; then
     CURRENT_TIME="$(date +%d.%m.%Y) $(date +%R)"
     curl https://www.cloudflare.com/ips-v4 -o /tmp/cf_ipv4
     curl https://www.cloudflare.com/ips-v6 -o /tmp/cf_ipv6
+    sed -i -e '$a\' /tmp/cf_ipv4
     cat /tmp/cf_ipv4 /tmp/cf_ipv6 > /tmp/cf_ips
 
     # Nginx


### PR DESCRIPTION
This is to avoid the "invalid address" prompt when combining the IPv4 and IPv6 files.